### PR TITLE
feat: 여행 계획 상세 카드 api 연동

### DIFF
--- a/src/api/trips/adapter.ts
+++ b/src/api/trips/adapter.ts
@@ -1,10 +1,8 @@
-// src/api/trips/adapter.ts
 import type { TripPlanApi, TripCardModel, TripPlanDetailApi, TripDetailModel } from './types';
 
 const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
 const fmtDate = (d?: string | null) => (d ? d.slice(0, 10).replaceAll('-', '.') : '');
 
-// --- 리스트용 기존 어댑터(그대로 유지) ---
 export function toTripCardModel(p: TripPlanApi): TripCardModel {
   const progress =
     p.totalBudget > 0 ? Math.round(clamp01(p.currentSavings / p.totalBudget) * 100) : 0;
@@ -23,7 +21,6 @@ export function toTripCardModel(p: TripPlanApi): TripCardModel {
   };
 }
 
-// --- 상세용 새 어댑터 ---
 export function toTripDetailModel(p: TripPlanDetailApi): TripDetailModel {
   const total = typeof p.totalBudget === 'number' ? p.totalBudget : 0;
   const saved = typeof p.currentSavings === 'number' ? p.currentSavings : 0;

--- a/src/api/trips/index.ts
+++ b/src/api/trips/index.ts
@@ -1,17 +1,26 @@
 import axios from '@/api/core/axiosInstance';
-import type { TripPlanApi, TripPlanDetailApi } from './types';
+import type { TripPlanApi, TripPlanDetailApi, TripBalanceApi } from './types';
 
+/** 여행 플랜 목록 */
 export async function fetchTripPlans(): Promise<TripPlanApi[]> {
   const { data } = await axios.get<TripPlanApi[]>('/trip-plans');
   return data;
 }
 
+/** 여행 플랜 상세 */
 export async function fetchTripPlanDetail(planId: number | string): Promise<TripPlanDetailApi> {
   const { data } = await axios.get<TripPlanDetailApi>(`/trip-plans/${planId}`);
   return data;
 }
 
+/** 여행 플랜 참여 멤버 초대/추가 */
 export async function addTripMembers(planId: number, emails: string[]) {
   const { data } = await axios.post(`/trip-plans/${planId}/members`, { email: emails });
+  return data;
+}
+
+/** 여행 플랜 참여 멤버별 계좌 잔액 및 달성률 조회 (잔액 내림차순) */
+export async function fetchTripPlanBalances(planId: number | string): Promise<TripBalanceApi[]> {
+  const { data } = await axios.get<TripBalanceApi[]>(`/trip-plans/${planId}/balances`);
   return data;
 }

--- a/src/api/trips/index.ts
+++ b/src/api/trips/index.ts
@@ -1,4 +1,3 @@
-// src/api/trips/index.ts
 import axios from '@/api/core/axiosInstance';
 import type { TripPlanApi, TripPlanDetailApi } from './types';
 

--- a/src/api/trips/queries.ts
+++ b/src/api/trips/queries.ts
@@ -1,12 +1,14 @@
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
-import { fetchTripPlans, fetchTripPlanDetail } from './index';
+import { fetchTripPlans, fetchTripPlanDetail, fetchTripPlanBalances } from './index';
 import { toTripCardModel, toTripDetailModel } from './adapter';
-import type { TripCardModel, TripDetailModel } from './types';
+import { toBalanceModel } from './adapter';
+import type { TripCardModel, TripDetailModel, TripBalanceModel } from './types';
 
 export const TRIP_KEYS = {
   all: ['tripPlans'] as const,
   detail: (id: number | string) => ['tripPlan', id] as const,
+  balances: (id: number | string) => ['tripPlan', id, 'balances'] as const,
 };
 
 export function useTripPlans() {
@@ -46,6 +48,20 @@ export function useTripPlanDetail(id?: number | string) {
     },
     retry: false,
     staleTime: 60_000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function useTripPlanBalances(id?: number | string) {
+  return useQuery({
+    queryKey: id ? TRIP_KEYS.balances(id) : ['tripPlan', 'empty', 'balances'],
+    enabled: !!id,
+    queryFn: async (): Promise<TripBalanceModel[]> => {
+      const data = await fetchTripPlanBalances(id!);
+      return data.map(toBalanceModel).sort((a, b) => b.percent - a.percent);
+    },
+    staleTime: 30_000,
     refetchOnMount: 'always',
     refetchOnWindowFocus: true,
   });

--- a/src/api/trips/queries.ts
+++ b/src/api/trips/queries.ts
@@ -1,4 +1,3 @@
-// src/api/trips/queries.ts
 import axios from 'axios';
 import { useQuery } from '@tanstack/react-query';
 import { fetchTripPlans, fetchTripPlanDetail } from './index';
@@ -32,7 +31,6 @@ export function useTripPlanDetail(id?: number | string) {
         const data = await fetchTripPlanDetail(id!);
         return toTripDetailModel(data);
       } catch (e) {
-        // 404 또는 백엔드가 500으로 던지지만 메시지가 "저축 플랜이 존재하지 않습니다!"인 경우
         if (axios.isAxiosError(e)) {
           const status = e.response?.status;
           const msg = e.response?.data?.message as string | undefined;
@@ -46,7 +44,7 @@ export function useTripPlanDetail(id?: number | string) {
         throw e;
       }
     },
-    retry: false, // 존재하지 않으면 재시도 불필요
+    retry: false,
     staleTime: 60_000,
     refetchOnMount: 'always',
     refetchOnWindowFocus: true,

--- a/src/api/trips/types.ts
+++ b/src/api/trips/types.ts
@@ -54,3 +54,19 @@ export type TripDetailModel = {
   cautions: string[];
   categories?: { name: string; amount: number }[];
 };
+
+export type TripBalanceApi = {
+  userId: number;
+  nickname: string;
+  profileImage?: string;
+  balance: number;
+  progress: number;
+};
+
+export type TripBalanceModel = {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+  balance: number;
+  percent: number;
+};

--- a/src/api/trips/types.ts
+++ b/src/api/trips/types.ts
@@ -1,5 +1,3 @@
-// src/api/trips/types.ts
-
 export type TripPlanApi = {
   planId: number;
   country: string;
@@ -21,7 +19,6 @@ export type TripCardModel = {
   membersCount: number;
 };
 
-// 상세 조회 응답 (리스트 공통 필드 + 상세 필드)
 export type TripMemberApi = {
   userId: number;
   nickname: string;
@@ -36,15 +33,14 @@ export type CategoryApi = {
 
 export type TripPlanDetailApi = TripPlanApi & {
   duration: number;
-  startDate?: string; // 저축 시작일(선택)
-  targetDate?: string; // 저축 목표일(선택)
+  startDate?: string;
+  targetDate?: string;
   savingsPhrase?: string[];
-  tripTip?: string[]; // 여행 팁
+  tripTip?: string[];
   categoryDTOList?: CategoryApi[];
   tripMemberDTOList?: TripMemberApi[];
 };
 
-// UI 모델 (상세 페이지용)
 export type TripDetailModel = {
   id: string;
   destination: string;
@@ -52,15 +48,9 @@ export type TripDetailModel = {
   period: string;
   thumbnailUrl: string;
   progressPercent: number;
-
-  // TripOverviewCard
   members: { id: string; name: string; percent: number; avatarUrl?: string }[];
-  overviewTip?: string; // TripOverviewCard에 넘길 한 줄 팁
-
-  // BeforeYouGoCard
+  overviewTip?: string;
   checklist: string[];
   cautions: string[];
-
-  // ExpenseCard 등에서 쓸 수 있는 원천 데이터(옵션)
   categories?: { name: string; amount: number }[];
 };

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -11,13 +11,16 @@ import FriendInviteModal from '@/components/modals/FriendInviteModal';
 import BankConnectModal from '@/components/modals/BankConnectModal';
 import podiumUrl from '@/assets/images/podium.svg';
 import { BANK_NAME_BY_CODE } from '@/constants/banks';
-import { useTripPlanDetail } from '@/api/trips/queries';
+import { useTripPlanDetail, useTripPlanBalances } from '@/api/trips/queries';
+import { useMe } from '@/api/users/queries';
 
 export default function DetailPage() {
   const { tripId } = useParams<{ tripId: string }>();
   const navigate = useNavigate();
 
   const { data, isLoading, isError, error } = useTripPlanDetail(tripId);
+  const { data: balances = [] } = useTripPlanBalances(tripId);
+  const { data: me } = useMe();
 
   const [openMenu, setOpenMenu] = useState(false);
   const [openInvite, setOpenInvite] = useState(false);
@@ -26,10 +29,34 @@ export default function DetailPage() {
   const [isAccountLinked, setIsAccountLinked] = useState(false);
   const [accountLabel, setAccountLabel] = useState<string | undefined>(undefined);
 
-  // 진행률은 서버 값 기반으로
   const progress = data?.progressPercent ?? 0;
 
-  // Overview/BeforeYouGoCard에 들어갈 값 메모
+  const podiumTop3 = useMemo(() => {
+    if (balances.length) {
+      return balances.slice(0, 3).map((b) => ({
+        id: b.id,
+        name: b.name,
+        percent: b.percent,
+        avatarUrl: b.avatarUrl,
+      }));
+    }
+    if (data?.members?.length) {
+      const sorted = [...data.members].sort((a, b) => b.percent - a.percent);
+      return sorted.slice(0, 3);
+    }
+    if (me) {
+      return [
+        {
+          id: String(me.id ?? 'me'),
+          name: me.nickname ?? me.email ?? 'Me',
+          percent: progress,
+          avatarUrl: me.profileImage,
+        },
+      ];
+    }
+    return [];
+  }, [balances, data?.members, me, progress]);
+
   const overview = useMemo(() => {
     if (!data) return null;
     return {
@@ -115,8 +142,6 @@ export default function DetailPage() {
           )}
         </div>
       </Container>
-
-      {/* 진행 상황 + 계좌 연동 */}
       <ProgressCard
         progress={progress}
         tip={data.overviewTip ?? '오늘도 한 걸음! 목표가 가까워지고 있어요.'}
@@ -127,11 +152,7 @@ export default function DetailPage() {
         }}
         onClickLink={() => setOpenBank(true)}
       />
-
-      {/* 예상 경비(저축률만 사용 중) */}
       <ExpenseCard savedPercent={progress} />
-
-      {/* 개요 카드 */}
       {overview && (
         <TripOverviewCard
           destination={overview.destination}
@@ -142,13 +163,10 @@ export default function DetailPage() {
           members={overview.members}
           podiumImageUrl={podiumUrl}
           tip={overview.tip}
+          podiumTop3={podiumTop3}
         />
       )}
-
-      {/* 체크리스트/주의사항 (백 응답에 없으면 빈 배열) */}
       <BeforeYouGoCard destination={data.destination} checklist={checklist} cautions={cautions} />
-
-      {/* 모달들 */}
       <FriendInviteModal isOpen={openInvite} onClose={() => setOpenInvite(false)} />
       <BankConnectModal
         isOpen={openBank}

--- a/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.style.ts
+++ b/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.style.ts
@@ -80,11 +80,57 @@ export const Divider = styled.hr`
   );
 `;
 
+export const PodiumStage = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
 export const Podium = styled.img`
-  width: 160px;
+  width: 180px;
   display: block;
-  margin: 3rem auto 2rem;
+  margin: 0;
   opacity: 0.95;
+`;
+
+export const PodiumWrap = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  margin: 4.2rem 0 1.5rem;
+`;
+
+export const TopAvatar = styled.div<{ $pos: 'first' | 'second' | 'third' }>`
+  position: absolute;
+  z-index: 2;
+
+  bottom: ${({ $pos }) => ($pos === 'first' ? '90%' : '56%')};
+  left: ${({ $pos }) => ($pos === 'first' ? '50%' : $pos === 'second' ? '26%' : '74%')};
+  transform: translate(-50%, 0%);
+
+  width: ${({ $pos }) => ($pos === 'first' ? '50px' : '42px')};
+  height: ${({ $pos }) => ($pos === 'first' ? '50px' : '42px')};
+  border-radius: 50%;
+  overflow: hidden;
+  border: 3px solid rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(3px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+
+  & > svg {
+    width: 100%;
+    height: 100%;
+    padding: 10px;
+    color: #cfcfcf;
+  }
+`;
+
+export const AvatarImg = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+  background: #2b2b2b;
 `;
 
 export const RankList = styled.ul`
@@ -110,16 +156,21 @@ export const RankNo = styled.span`
 `;
 
 export const RankUser = styled.span`
+  --rank-avatar-size: 2rem;
+  --rank-gap: 0.6rem;
+
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--rank-gap);
+  font-weight: 600;
+  letter-spacing: 0.2px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 
   & > svg {
-    width: 1.125rem;
-    height: 1.125rem;
+    width: var(--rank-avatar-size);
+    height: var(--rank-avatar-size);
     color: #bdbdbd;
     flex-shrink: 0;
   }
@@ -144,4 +195,14 @@ export const TipText = styled.p`
   margin: 0;
   line-height: 1.45;
   opacity: 0.95;
+`;
+
+export const RankAvatarImg = styled.img`
+  width: var(--rank-avatar-size);
+  height: var(--rank-avatar-size);
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+  flex-shrink: 0;
+  background: #2b2b2b;
 `;

--- a/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.style.ts
+++ b/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Card from '@/components/common/Card/Card';
+import { Crown as CrownSvg } from 'lucide-react';
 import {
   Header as BaseHeader,
   DestinationBox,
@@ -96,32 +97,46 @@ export const PodiumWrap = styled.div`
   position: relative;
   display: flex;
   justify-content: center;
-  margin: 4.2rem 0 1.5rem;
+  margin: 5rem 0 1.5rem;
 `;
 
 export const TopAvatar = styled.div<{ $pos: 'first' | 'second' | 'third' }>`
   position: absolute;
   z-index: 2;
 
-  bottom: ${({ $pos }) => ($pos === 'first' ? '90%' : '56%')};
-  left: ${({ $pos }) => ($pos === 'first' ? '50%' : $pos === 'second' ? '26%' : '74%')};
+  bottom: ${({ $pos }) => ($pos === 'first' ? '87%' : $pos === 'second' ? '58%' : '50%')};
+  left: ${({ $pos }) => ($pos === 'first' ? '50%' : $pos === 'second' ? '15%' : '85.5%')};
   transform: translate(-50%, 0%);
 
-  width: ${({ $pos }) => ($pos === 'first' ? '50px' : '42px')};
-  height: ${({ $pos }) => ($pos === 'first' ? '50px' : '42px')};
+  width: ${({ $pos }) => ($pos === 'first' ? '50px' : '40px')};
+  height: ${({ $pos }) => ($pos === 'first' ? '50px' : '40px')};
   border-radius: 50%;
-  overflow: hidden;
-  border: 3px solid rgba(255, 255, 255, 0.9);
+  overflow: visible;
+  border: 2px solid ${({ $pos }) => ($pos === 'first' ? '#edd718ff' : 'rgba(255, 255, 255, 0.9)')};
   background: rgba(255, 255, 255, 0.06);
   backdrop-filter: blur(3px);
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
 
-  & > svg {
+  & > svg:not(.crown) {
     width: 100%;
     height: 100%;
     padding: 10px;
     color: #cfcfcf;
   }
+`;
+
+export const CrownIcon = styled(CrownSvg).attrs({ className: 'crown' })`
+  position: absolute;
+  bottom: calc(100% + 3px);
+  left: 50%;
+  transform: translateX(-50%);
+
+  width: 27px;
+  height: 25px;
+
+  stroke: #edd718ff;
+  fill: none;
+  pointer-events: none;
 `;
 
 export const AvatarImg = styled.img`

--- a/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
+++ b/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
@@ -18,6 +18,8 @@ import {
   ProgressRightLabel,
   Divider,
   Podium,
+  PodiumWrap,
+  TopAvatar,
   RankList,
   RankItem,
   RankNo,
@@ -26,10 +28,13 @@ import {
   Tip,
   TipLabel,
   TipText,
+  AvatarImg,
+  RankAvatarImg,
+  PodiumStage,
 } from './TripOverviewCard.style';
 import { CircleUserRound } from 'lucide-react';
 
-type Member = { id: string; name: string; percent: number };
+type Member = { id: string; name: string; percent: number; avatarUrl?: string };
 
 type Props = {
   destination: string;
@@ -40,6 +45,8 @@ type Props = {
   members: Member[];
   tip?: string;
   podiumImageUrl?: string;
+  /** balances 기반 TOP3 (percent desc). 없으면 단상 위 아바타 미표시 */
+  podiumTop3?: Member[];
 };
 
 const TILE_ROWS = 2;
@@ -54,6 +61,37 @@ function shuffle<T>(array: T[]): T[] {
   return copy;
 }
 
+function RankAvatar({ url, alt }: { url?: string; alt: string }) {
+  const [failed, setFailed] = useState(false);
+  return url && !failed ? (
+    <RankAvatarImg src={url} alt={alt} onError={() => setFailed(true)} />
+  ) : (
+    <CircleUserRound />
+  );
+}
+
+function PodiumAvatar({
+  url,
+  alt,
+  pos,
+}: {
+  url?: string;
+  alt: string;
+  pos: 'first' | 'second' | 'third';
+}) {
+  const [failed, setFailed] = useState(false);
+
+  return (
+    <TopAvatar $pos={pos} aria-label={alt}>
+      {url && !failed ? (
+        <AvatarImg src={url} alt={alt} onError={() => setFailed(true)} />
+      ) : (
+        <CircleUserRound />
+      )}
+    </TopAvatar>
+  );
+}
+
 export default function TripOverviewCard({
   destination,
   countryCode,
@@ -63,6 +101,7 @@ export default function TripOverviewCard({
   members,
   tip,
   podiumImageUrl,
+  podiumTop3,
 }: Props) {
   const totalTiles = TILE_ROWS * TILE_COLS;
   const orderRef = useRef<number[]>(shuffle([...Array(totalTiles).keys()]));
@@ -132,21 +171,49 @@ export default function TripOverviewCard({
 
       <Divider />
 
-      {podiumImageUrl && <Podium src={podiumImageUrl} alt="랭킹 단상" />}
+      {podiumImageUrl && (
+        <PodiumWrap>
+          <PodiumStage>
+            {podiumTop3?.[1] && (
+              <PodiumAvatar
+                pos="second"
+                url={podiumTop3[1].avatarUrl}
+                alt={`${podiumTop3[1].name} 프로필`}
+              />
+            )}
+            {podiumTop3?.[0] && (
+              <PodiumAvatar
+                pos="first"
+                url={podiumTop3[0].avatarUrl}
+                alt={`${podiumTop3[0].name} 프로필`}
+              />
+            )}
+            {podiumTop3?.[2] && (
+              <PodiumAvatar
+                pos="third"
+                url={podiumTop3[2].avatarUrl}
+                alt={`${podiumTop3[2].name} 프로필`}
+              />
+            )}
+
+            {/* 단상 이미지 */}
+            <Podium src={podiumImageUrl} alt="랭킹 단상" />
+          </PodiumStage>
+        </PodiumWrap>
+      )}
 
       <RankList>
         {members.map((m, idx) => (
           <RankItem key={m.id}>
             <RankNo>{idx + 1}</RankNo>
             <RankUser>
-              <CircleUserRound />
+              <RankAvatar url={m.avatarUrl} alt={`${m.name} 프로필`} />
               {m.name}
             </RankUser>
             <RankPercent>{m.percent}%</RankPercent>
           </RankItem>
         ))}
       </RankList>
-
       <Divider />
       <Tip>
         <TipLabel>TIP</TipLabel>

--- a/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
+++ b/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
@@ -45,7 +45,6 @@ type Props = {
   members: Member[];
   tip?: string;
   podiumImageUrl?: string;
-  /** balances 기반 TOP3 (percent desc). 없으면 단상 위 아바타 미표시 */
   podiumTop3?: Member[];
 };
 

--- a/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
+++ b/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
@@ -31,6 +31,7 @@ import {
   AvatarImg,
   RankAvatarImg,
   PodiumStage,
+  CrownIcon,
 } from './TripOverviewCard.style';
 import { CircleUserRound } from 'lucide-react';
 
@@ -82,6 +83,7 @@ function PodiumAvatar({
 
   return (
     <TopAvatar $pos={pos} aria-label={alt}>
+      {pos === 'first' && <CrownIcon aria-hidden="true" />}
       {url && !failed ? (
         <AvatarImg src={url} alt={alt} onError={() => setFailed(true)} />
       ) : (


### PR DESCRIPTION
## 🔗 반영 브랜치
- closed #45 
- `feature/detail-trip-card-api→ develop` 

## 📝 작업 내용
- 1위~3위 랭킹 단상 api 연결
<img width="241" height="209" alt="스크린샷 2025-09-10 오후 10 02 37" src="https://github.com/user-attachments/assets/6a90c4d4-378a-4ddb-b05a-6bf220cec7f9" />

## 💬 리뷰 요구사항(선택 사항)
.
