### PR TITLE
Feat: 인원수 api 연동

### DIFF
--- a/src/api/trips/adapter.ts
+++ b/src/api/trips/adapter.ts
@@ -57,7 +57,7 @@ export function toTripCardModel(p: TripPlanApi): TripCardModel {
     period: `${(p.tripStartDate ?? '').slice(0, 10).replaceAll('-', '.')} - ${(p.tripEndDate ?? '').slice(0, 10).replaceAll('-', '.')}`,
     thumbnailUrl: '/assets/images/trip-placeholder.jpg',
     progressPercent: progress,
-    membersCount: 1,
+    membersCount: p.memberCount ?? 1,
   };
 }
 

--- a/src/api/trips/types.ts
+++ b/src/api/trips/types.ts
@@ -9,6 +9,7 @@ export type TripPlanApi = {
   tripEndDate: string;
   totalBudget: number;
   currentSavings: number;
+  memberCount: number;
 };
 
 export type TripCardModel = {

--- a/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
+++ b/src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
@@ -1,4 +1,3 @@
-// src/pages/DetailPage/sections/TripOverviewCard/TripOverviewCard.tsx
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Wrapper,


### PR DESCRIPTION
## 🔗 반영 브랜치
- closed #74 
- `feature/personnel-count-api → develop`

## 📝 작업 내용
- Plan 탭 눌렀을 때 여행 계획 목록에 인원수 api 연동
<img width="342" height="619" alt="스크린샷 2025-10-28 오후 4 09 01" src="https://github.com/user-attachments/assets/ba8d0a80-31a2-4d6f-a48a-a740bf3ebbb5" />

## 💬 리뷰 요구사항(선택 사항)
.
