### PR TITLE
Refactor: 여행 상세보기 api 중복 호출, 계좌 잔액 조회 버그 수정

### DIFF
--- a/src/api/trips/adapter.ts
+++ b/src/api/trips/adapter.ts
@@ -94,7 +94,11 @@ export function toTripDetailModel(p: TripPlanDetailApi): TripDetailModel {
     tips,
     checklist,
     cautions,
-    categories: p.categoryDTOList?.map((c) => ({ name: c.categoryName, amount: c.amount })),
+    categories: p.categoryDTOList?.map((c) => ({ 
+      name: c.categoryName, 
+      amount: c.amount,
+      consumed: c.consumed ?? false,
+    })),
     totalBudget: total,
     currentSavings: saved,
   };

--- a/src/api/trips/index.ts
+++ b/src/api/trips/index.ts
@@ -22,7 +22,6 @@ export async function addTripMembers(planId: number, emails: string[]) {
 /* 여행 플랜 참여 멤버별 계좌 잔액 및 달성률 조회 (잔액 내림차순) */
 export async function fetchTripPlanBalances(planId: number | string): Promise<TripBalanceApi[]> {
   const { data } = await axios.get<TripBalanceApi[]>(`/trip-plans/${planId}/balances`);
-  console.log(data);
   return data;
 }
 

--- a/src/api/trips/queries.ts
+++ b/src/api/trips/queries.ts
@@ -65,7 +65,6 @@ export function useTripPlanBalances(id?: number | string) {
     enabled: !!id,
     queryFn: async (): Promise<TripBalanceModel[]> => {
       const data = await fetchTripPlanBalances(id!);
-      console.log(data);
       return data.map(toBalanceModel).sort((a, b) => b.percent - a.percent);
     },
     staleTime: 30_000,

--- a/src/api/trips/queries.ts
+++ b/src/api/trips/queries.ts
@@ -54,8 +54,8 @@ export function useTripPlanDetail(id?: number | string) {
     },
     retry: false,
     staleTime: 60_000,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/src/api/trips/types.ts
+++ b/src/api/trips/types.ts
@@ -32,6 +32,7 @@ export type TripMemberApi = {
 export type CategoryApi = {
   categoryName: string;
   amount: number;
+  consumed?: boolean;
 };
 
 export type TripPlanDetailApi = TripPlanApi & {
@@ -57,7 +58,7 @@ export type TripDetailModel = {
   tips?: TipItem[];
   checklist: string[];
   cautions: string[];
-  categories?: { name: string; amount: number }[];
+  categories?: { name: string; amount: number; consumed?: boolean }[];
   totalBudget: number;
   currentSavings: number;
   savingsPhrases?: string[];

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -319,7 +319,16 @@ useEffect(() => {
       />
 
       {/* 예상 경비/목표 달성 */}
-      <ExpenseCard tripId={id} savedPercent={progress} />
+      <ExpenseCard
+        tripId={id}
+        savedPercent={progress}
+        categories={data?.categories}
+        onDataChange={async () => {
+          // ExpenseCard에서 데이터 변경 시 쿼리 무효화하여 재조회
+          await qc.invalidateQueries({ queryKey: TRIP_KEYS.detail(id), exact: true });
+          await qc.invalidateQueries({ queryKey: TRIP_KEYS.balances(id), exact: true });
+        }}
+      />
 
       {overview && (
         <TripOverviewCard

--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -102,44 +102,56 @@ export default function DetailPage() {
     return (balances as any[]).find((b) => String(b.id) === String(meId));
   }, [balances, meId]);
 
-// ---------- balances 기반으로 계좌 상태 세팅 ----------
-useEffect(() => {
-  if (!tripId) return;
+  // ---------- balances 기반으로 계좌 상태 세팅 ----------
+  // balances API 응답(UserBalanceResponseDTO[])을 기반으로 계좌 연동 상태 자동 업데이트
+  useEffect(() => {
+    if (!tripId) return;
 
-  const planIdNum = Number(tripId);
-  const rows = (balances ?? []) as any[];
+    const planIdNum = Number(tripId);
+    const rows = (balances ?? []) as any[];
 
-  // balances 자체가 없으면 = 계좌 미연동 처리
-  if (!rows.length) {
-    setIsAccountLinked(false);
-    setAccountLabel(undefined);
-    setAccountBalance(undefined);
-    setLinkedForPlan(planIdNum, false);
-    return;
-  }
+    // balances 자체가 없으면 = 계좌 미연동 처리
+    if (!rows.length) {
+      setIsAccountLinked(false);
+      setAccountLabel(undefined);
+      setAccountBalance(undefined);
+      setLinkedForPlan(planIdNum, false);
+      return;
+    }
 
-  // 내 id 기준으로 행 찾기 (TripBalanceModel은 id 필드 사용, 없으면 첫 번째 행 사용)
-  const target =
-    meId != null
-      ? rows.find((b) => String(b.id) === String(meId))
-      : rows[0];
+    // 내 id 기준으로 행 찾기
+    // adapter를 거친 후: TripBalanceModel { id: string, name, avatarUrl, balance, percent }
+    // adapter 변환: id = String(userId)
+    // meId가 유효한 값(양수)이고 매칭되는 항목이 있으면 사용, 없으면 첫 번째 항목 사용
+    let target = undefined;
+    if (meId != null && meId > 0) {
+      target = rows.find((b) => String(b.id) === String(meId));
+    }
+    // meId로 찾지 못했거나 meId가 유효하지 않으면 첫 번째 항목 사용
+    if (!target && rows.length > 0) {
+      target = rows[0];
+    }
 
-  // 잔액 정보가 없으면 = 미연동으로 본다
-  if (!target || target.balance == null) {
-    setIsAccountLinked(false);
-    setAccountLabel(undefined);
-    setAccountBalance(undefined);
-    setLinkedForPlan(planIdNum, false);
-    return;
-  }
+    // 잔액 정보가 null이거나 undefined이면 = 미연동으로 본다
+    // balance가 0인 경우는 유효한 값이므로 체크하지 않음
+    if (!target || target.balance === null || target.balance === undefined) {
+      setIsAccountLinked(false);
+      setAccountLabel(undefined);
+      setAccountBalance(undefined);
+      setLinkedForPlan(planIdNum, false);
+      return;
+    }
 
-  // 여기까지 왔으면 계좌 연동된 상태로 간주
-  setIsAccountLinked(true);
-  setAccountBalance(Number(target.balance));
-  setAccountLabel('연동된 계좌');
-  setLinkedForPlan(planIdNum, true);
-}, [tripId, balances, meId]);
-
+    // 여기까지 왔으면 계좌 연동된 상태로 간주
+    setIsAccountLinked(true);
+    setAccountBalance(Number(target.balance));
+    // accountLabel은 handleBankConnected에서 설정하거나, 없으면 기본값
+    // useEffect에서는 balances 기반으로 isAccountLinked와 balance만 업데이트
+    if (!accountLabel) {
+      setAccountLabel('연동된 계좌');
+    }
+    setLinkedForPlan(planIdNum, true);
+  }, [tripId, balances, meId]);
 
   // ---------- 멤버 리스트 ----------
   const groupMembers = useMemo(() => {
@@ -230,21 +242,33 @@ useEffect(() => {
   const cautions = useMemo(() => data?.cautions ?? [], [data?.cautions]);
 
   // ---------- 계좌 연동 완료 핸들러 ----------
-  // 계좌 연동 후에는 CODEF API를 다시 호출하지 않고, balances 쿼리만 새로고침
+  // 계좌 연동 후 /trip-plans/{tripPlanId}/balances API를 refetch하여 최신 데이터 가져오기
+  // 이 API는 모든 멤버의 계좌와 달성율(UserBalanceResponseDTO)을 반환하므로 바로 활용
   const handleBankConnected = async (bankCode: string, acct: string) => {
     const planId = Number(tripId);
     setLinkedForPlan(planId, true);
     setBankOrgForPlan(planId, bankCode);
 
-    // balances 쿼리를 무효화해서 /trip-plans/{tripPlanId}/balances API로 최신 데이터 가져오기
-    // refreshTripPlanBalance(CODEF API)는 최초 계좌 연결 시에만 BankConnectModal에서 호출됨
-    await qc.invalidateQueries({ queryKey: TRIP_KEYS.balances(planId), exact: true });
-
     const bankName = BANK_NAME_BY_CODE[bankCode as keyof typeof BANK_NAME_BY_CODE] ?? '연동 계좌';
     const maskAccount = (s: string) => s.replace(/\d(?=\d{4})/g, '*');
+
+    // 계좌 연동 상태 즉시 설정 (버튼 숨기기)
     setIsAccountLinked(true);
     setAccountLabel(`${bankName} ${maskAccount(acct)}`);
-    // 잔액은 balances 쿼리에서 가져온 데이터로 useEffect에서 자동 설정됨
+
+    // balances API를 invalidate하여 최신 데이터 가져오기
+    // useEffect가 balances 변경을 감지하여 balance와 progress 자동 업데이트
+    await qc.invalidateQueries({
+      queryKey: TRIP_KEYS.balances(planId),
+      exact: true,
+    });
+
+    // detail 쿼리도 함께 invalidate
+    await qc.invalidateQueries({
+      queryKey: TRIP_KEYS.detail(planId),
+      exact: true,
+    });
+
     setOpenBank(false);
   };
 

--- a/src/pages/DetailPage/sections/ExpenseCard/ExpenseCard.tsx
+++ b/src/pages/DetailPage/sections/ExpenseCard/ExpenseCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Plane, Home, Utensils, Check } from 'lucide-react';
 import { PiAirplaneTiltFill } from 'react-icons/pi';
 import EditModal from '../../../../components/common/EditModal';
@@ -27,61 +27,42 @@ type ExpenseItem = {
 type Props = {
   savedPercent: number;
   tripId: number;
+  categories?: { name: string; amount: number; consumed?: boolean }[];
+  onDataChange?: () => void;
 };
 
 const BASE_URL = import.meta.env.VITE_API_URL as string;
-export default function ExpenseCard({ savedPercent, tripId }: Props) {
-  const [items, setItems] = useState<ExpenseItem[]>([]);
+export default function ExpenseCard({ savedPercent, tripId, categories = [], onDataChange }: Props) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const token = localStorage.getItem('accessToken');
 
-  // 여행 경비 항목 불러오기 함수 (PATCH 후에도 재사용)
-  const fetchExpenses = async () => {
-    try {
-      const res = await fetch(`${BASE_URL}/trip-plans/${tripId}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: token ? `Bearer ${token}` : '',
-        },
-      });
+  // categories를 ExpenseItem 형식으로 변환
+  const items = useMemo<ExpenseItem[]>(() => {
+    return categories.map((c) => {
+      let icon;
+      switch (c.name) {
+        case '항공비':
+          icon = <Plane size={18} />;
+          break;
+        case '숙박':
+          icon = <Home size={18} />;
+          break;
+        case '식비':
+          icon = <Utensils size={18} />;
+          break;
+        default:
+          icon = <Check size={18} />;
+      }
 
-      const data = await res.json();
-
-      const mappedItems: ExpenseItem[] = data.categoryDTOList.map((c: any) => {
-        let icon;
-        switch (c.categoryName) {
-          case '항공비':
-            icon = <Plane size={18} />;
-            break;
-          case '숙박':
-            icon = <Home size={18} />;
-            break;
-          case '식비':
-            icon = <Utensils size={18} />;
-            break;
-          default:
-            icon = <Check size={18} />;
-        }
-
-        return {
-          id: c.categoryName,
-          label: c.categoryName,
-          amount: c.amount,
-          icon,
-          purchased: c.consumed ?? false, // /trip-plans 응답엔 없을 수 있음 → false 처리
-        };
-      });
-
-      setItems(mappedItems);
-    } catch (err) {
-      console.error('Failed to fetch expenses', err);
-    }
-  };
-
-  useEffect(() => {
-    fetchExpenses();
-  }, [tripId]);
+      return {
+        id: c.name,
+        label: c.name,
+        amount: c.amount,
+        icon,
+        purchased: c.consumed ?? false,
+      };
+    });
+  }, [categories]);
 
   // 총합 & 진행률 기반 커버 계산 (부모 progress 사용)
   const total = items.reduce((sum, i) => sum + i.amount, 0);
@@ -121,18 +102,8 @@ export default function ExpenseCard({ savedPercent, tripId }: Props) {
         body: JSON.stringify(bodyData),
       });
 
-      // ✅ 증가량 = (해당 항목 금액 / 총합) * 100
-      const rawDelta = (item.amount / total) * 100;
-      const delta = Math.round(rawDelta * 10) / 10; // 보기 좋게 소수 1자리
-
-      // // 부모(DetailPage) 진행률 즉시 반영
-      // onProgressDelta?.(delta);
-
-      // 로컬 purchased 갱신 (버튼 비활성 & 체크마크 표시)
-      setItems((prev) => prev.map((it) => (it.id === id ? { ...it, purchased: true } : it)));
-
-      // (선택) /isconsumed/{tripId} 로 재조회해서 확정 상태 싱크하고 싶다면:
-      // await fetchExpenses();
+      // 부모 컴포넌트에 데이터 새로고침 요청
+      onDataChange?.();
     } catch (err) {
       console.error('Failed to mark as consumed', err);
     }
@@ -158,9 +129,9 @@ export default function ExpenseCard({ savedPercent, tripId }: Props) {
         },
         body: JSON.stringify(bodyData),
       });
-      // 요청 후 로컬 업데이트
-      setItems(updatedItems);
-      // ⚠️ 합계 변경 후 delta 의미가 달라질 수 있으니, 부모에서 balances 무효화로 동기화하는 걸 추천
+      
+      // 부모 컴포넌트에 데이터 새로고침 요청
+      onDataChange?.();
     } catch (err) {
       console.error('Failed to update expenses', err);
     }


### PR DESCRIPTION
## 🔗 반영 브랜치

(#이슈번호) 현재 브랜치 -> 반영 브랜치

open #91 
`refactor/trip-plan → develop`


## 📝 작업 내용
- API 호출 최적화
(변경 전)
<img width="377" height="442" alt="image" src="https://github.com/user-attachments/assets/fff8655b-e613-4bf1-b6de-f843a5505046" />

<br>

(변경 후)
<img width="381" height="446" alt="image" src="https://github.com/user-attachments/assets/5f280d73-b038-405d-97ad-fe8a3550c093" />

<hr>

- 계좌 잔액 조회 버그 수정
<img width="353" height="268" alt="image" src="https://github.com/user-attachments/assets/f3cb39b4-1b18-4605-97f9-753b2d0fe0f2" />


## 💬 리뷰 요구사항(선택 사항)

