### PR TITLE
Refactor: 뒤로가기 오류 수정 및 여행 팁 미존재 시 안내 메시지 추가

### DIFF
--- a/src/pages/DetailPage/DetailPage.tsx
+++ b/src/pages/DetailPage/DetailPage.tsx
@@ -320,7 +320,7 @@ export default function DetailPage() {
   return (
     <div>
       <Container>
-        <LeftIcon onClick={() => navigate(-1)} />
+        <LeftIcon onClick={() => navigate(-2)} />
         <RightIcon onClick={() => setOpenMenu((s) => !s)} />
         {openMenu && (
           <Dropdown>

--- a/src/pages/DetailPage/sections/BeforeYouGoCard/BeforeYouGoCard.tsx
+++ b/src/pages/DetailPage/sections/BeforeYouGoCard/BeforeYouGoCard.tsx
@@ -68,20 +68,25 @@ export default function BeforeYouGoCard({ destination, checklist, cautions, tips
         </Section>
       )} */}
 
-      {showTips && (
-        <Section>
-          <SectionTitle>
-            <Sparkles aria-hidden /> 현지 꿀팁
-          </SectionTitle>
-          <BulletList role="list">
-            {tips!.map((tip, i) => (
+      <Section>
+        <SectionTitle>
+          <Sparkles aria-hidden /> 현지 꿀팁
+        </SectionTitle>
+
+        <BulletList role="list">
+          {showTips ? (
+            tips!.map((tip, i) => (
               <ListItem role="listitem" key={`tip-${i}`}>
                 {tip.label ? <strong>{tip.label}:</strong> : null} {tip.text}
               </ListItem>
-            ))}
-          </BulletList>
-        </Section>
-      )}
+            ))
+          ) : (
+            <ListItem role="listitem" style={{ opacity: 0.8 }}>
+               여행 팁이 아직 준비 중이에요!
+            </ListItem>
+          )}
+        </BulletList>
+      </Section>
     </Wrapper>
   );
 }


### PR DESCRIPTION
## 🔗 반영 브랜치
refactor/error-correction -> develop


## 📝 작업 내용
1. 상세보기 페이지에서 뒤로가기 클릭 시 썸네일(타일 이미지)이 잠시 노출된 후 이동하는 문제를 수정
2. 여행팁 데이터가 아직 연동되지 않은 경우, 기본 안내 문구(“여행 팁이 아직 준비 중이에요!”)가 표시되도록 처리

## 💬 리뷰 요구사항(선택 사항)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 예시) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
